### PR TITLE
Bump version numbers for 5.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OME POI
 
 [![Build Status](https://travis-ci.org/ome/ome-poi.png)](http://travis-ci.org/ome/ome-poi)
+[![Maven Central](https://img.shields.io/maven-central/v/org.openmicroscopy/ome-poi.svg)](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.openmicroscopy%22%20AND%20a%3A%22ome-poi%22)
+[![Javadocs](http://javadoc.io/badge/org.openmicroscopy/ome-poi.svg)](http://javadoc.io/doc/org.openmicroscopy/ome-poi)
 
 Java API to handle Microsoft OLE 2 Compound Document format (Word, Excel). Based on poi-2.5.1-final-20040804.jar, with bugfixes for OLE v2 and memory efficiency improvements. Used by Bio-Formats for OLE support (cxd, ipw, oib, zvi). Used by VisBio overlays logic for XLS export feature.
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.openmicroscopy</groupId>
   <artifactId>ome-poi</artifactId>
-  <version>5.3.0-SNAPSHOT</version>
+  <version>5.3.0</version>
 
   <name>OME POI</name>
   <description>Java API to handle Microsoft OLE 2 Compound Document format (Word, Excel). Based on poi-2.5.1-final-20040804.jar, with bugfixes for OLE v2 and memory efficiency improvements. Used by Bio-Formats for OLE support (cxd, ipw, oib, zvi). Used by VisBio overlays logic for XLS export feature.</description>


### PR DESCRIPTION
This PR prepares the `ome-poi` repository for release and deployment on Maven Central including:
- bump of the version number to 5.3.0
- addition of badges linking to Maven Central and the Javadocs (currently broken - will be active post release)

/cc @dgault 