### PR TITLE
Bump commons-logging version to 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.1.1</version>
+      <version>1.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumping commons-logging to 1.2

This will bring commons-logging in line with both OMERO and OMEZarrReader and should prevent the issue seen in https://github.com/ome/openmicroscopy/pull/6328