### PR TITLE
Fix for EscherGraphics2d drawString method

### DIFF
--- a/src/main/java/loci/poi/hssf/usermodel/EscherGraphics2d.java
+++ b/src/main/java/loci/poi/hssf/usermodel/EscherGraphics2d.java
@@ -331,7 +331,7 @@ public class EscherGraphics2d extends Graphics2D
 
     public void drawString(AttributedCharacterIterator attributedcharacteriterator, int x, int y)
     {
-        drawString(attributedcharacteriterator, x, y);
+        getEscherGraphics().drawString(attributedcharacteriterator, x, y);
     }
 
     public void fill(Shape shape)


### PR DESCRIPTION
Fixes an issue raised in https://github.com/ome/ome-poi/issues/13

This seems to have been fixed in the upstream project a while back (https://svn.apache.org/viewvc?view=revision&revision=1044405). This PR only covers 1 of those fixes so it may be worth deciding if it is worth the effort to bring this project more in line with the upstream.

Fixes https://github.com/ome/ome-poi/issues/13