### PR TITLE
Add JDK 21 to the build matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11, 17, 21]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,9 +19,9 @@ jobs:
     env:
       maven_commands: install # default is install
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'

--- a/pom.xml
+++ b/pom.xml
@@ -144,10 +144,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
-        <!-- Require the Java 7 platform. -->
+        <!-- Require the Java 8 platform. -->
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
See https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-image/495/

- Bump the minimal requirements to JDK 8
- Bump the GitHub actions to run on Node.js 20