### PR TITLE
Update publication system to use Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,16 +88,6 @@
     <system>Jenkins</system>
     <url>https://ci.openmicroscopy.org/</url>
   </ciManagement>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
     <ome-common.version>6.0.22</ome-common.version>
@@ -344,19 +334,6 @@
       <id>release</id>
       <build>
         <plugins>
-          <!-- Stage releases with nexus -->
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-
           <!-- gpg release signing -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -371,6 +348,17 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,16 +12,16 @@
 
   <name>OME POI</name>
   <description>Java API to handle Microsoft OLE 2 Compound Document format (Word, Excel). Based on poi-2.5.1-final-20040804.jar, with bugfixes for OLE v2 and memory efficiency improvements. Used by Bio-Formats for OLE support (cxd, ipw, oib, zvi). Used by VisBio overlays logic for XLS export feature.</description>
-  <url>http://jakarta.apache.org/poi/</url>
+  <url>https://poi.apache.org/</url>
   <inceptionYear>2008</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -53,23 +53,6 @@
     <contributor><name>Christoph Sommer</name></contributor>
   </contributors>
 
-  <mailingLists>
-    <mailingList>
-      <name>OME-users</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
-      <post>ome-users@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
-    </mailingList>
-    <mailingList>
-      <name>OME-devel</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
-      <post>ome-devel@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
-    </mailingList>
-  </mailingLists>
-
   <prerequisites>
     <maven>3.0.5</maven>
   </prerequisites>
@@ -78,15 +61,15 @@
     <connection>scm:git:https://github.com/ome/ome-poi</connection>
     <developerConnection>scm:git:git@github.com:ome/ome-poi</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/ome/ome-poi</url>
+    <url>https://github.com/ome/ome-poi</url>
   </scm>
   <issueManagement>
-    <system>Trac</system>
-    <url>https://trac.openmicroscopy.org/ome</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/ome-poi/issues</url>
   </issueManagement>
   <ciManagement>
-    <system>Jenkins</system>
-    <url>https://ci.openmicroscopy.org/</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/ome-poi/actions</url>
   </ciManagement>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <configuration>
           <failOnError>false</failOnError>
           <links>
-            <link>http://docs.oracle.com/javase/7/docs/api/</link>
+            <link>https://docs.oracle.com/javase/8/docs/api/</link>
           </links>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -133,11 +133,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.14.0</version>
         <!-- Require the Java 8 platform. -->
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>8</source>
+          <target>8</target>
+          <release>8</release>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
   </ciManagement>
 
   <properties>
-    <ome-common.version>6.0.22</ome-common.version>
+    <ome-common.version>6.0.26</ome-common.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
See https://central.sonatype.org/news/20250326_ossrh_sunset/ for more context as well as https://github.com/ome/ome-common-java/pull/101 and https://github.com/ome/ome-contributing/pull/37

-adjusts the `release` profile to use `central-publishing-maven-plugin` and remove OSSRH repositories
- update `maven-compiler-plugin` to 3.14.0 and set the javac release option to 8
- bump `org.openmicroscopy:ome-common` from 6.0.22 to 6.0.26
- link to the Java 8 API documentation
- update outdated metadata